### PR TITLE
Fixed url to Boost source

### DIFF
--- a/deps/Boost/Boost.cmake
+++ b/deps/Boost/Boost.cmake
@@ -137,7 +137,7 @@ endif ()
 
 ExternalProject_Add(
     dep_Boost
-    URL "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.zip"
+    URL "https://archives.boost.io/release/1.78.0/source/boost_1_78_0.zip"
     URL_HASH SHA256=f22143b5528e081123c3c5ed437e92f648fe69748e95fa6e2bd41484e2986cc3
     DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/Boost
     CONFIGURE_COMMAND "${_bootstrap_cmd}"


### PR DESCRIPTION
Frog is not working anymore. Now url is pointing to file hosted on official boost.io (sha256sum didn't change)